### PR TITLE
Ability to add user permissions automatically added

### DIFF
--- a/rigpl_erpnext/hooks.py
+++ b/rigpl_erpnext/hooks.py
@@ -86,6 +86,9 @@ doc_events = {
 		"validate": "rigpl_erpnext.rigpl_erpnext.validations.stock_entry.validate",
 		"on_submit": "rigpl_erpnext.rigpl_erpnext.validations.stock_entry.validate"
 	},
+	"Lead": {
+		"on_update": "rigpl_erpnext.rigpl_erpnext.validations.lead.on_update"
+	},
 }
 
 # Scheduled Tasks

--- a/rigpl_erpnext/hooks.py
+++ b/rigpl_erpnext/hooks.py
@@ -89,6 +89,9 @@ doc_events = {
 	"Lead": {
 		"on_update": "rigpl_erpnext.rigpl_erpnext.validations.lead.on_update"
 	},
+	"Customer": {
+		"on_update": "rigpl_erpnext.rigpl_erpnext.validations.customer.on_update"
+	},
 }
 
 # Scheduled Tasks

--- a/rigpl_erpnext/rigpl_erpnext/validations/customer.py
+++ b/rigpl_erpnext/rigpl_erpnext/validations/customer.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import frappe
+from frappe import msgprint
+import frappe.permissions
+
+def on_update(doc,method):
+	allowed_ids = []
+	for d in doc.sales_team:
+		if d.sales_person:
+			s_person = frappe.get_doc("Sales Person", d.sales_person)
+			emp = frappe.get_doc("Employee", s_person.employee)
+			if emp.status == "Active":
+				frappe.permissions.add_user_permission("Customer", doc.name, emp.user_id)
+				allowed_ids.extend([emp.user_id])
+			else:
+				frappe.msgprint("Selected Sales Person is Not an Active Employee", raise_exception=1)
+	if doc.default_sales_partner:
+		s_partner = frappe.get_doc("Sales Partner", doc.default_sales_partner)
+		user = frappe.get_doc("User", s_partner.user)
+		if user.enabled == 1:
+			frappe.permissions.add_user_permission("Customer", doc.name, s_partner.user)
+			allowed_ids.extend([s_partner.user])
+			#frappe.msgprint(allowed_ids)
+	
+	query = """SELECT name, parent from `tabDefaultValue` where defkey = 'Customer' AND defvalue = '%s'""" % (doc.name)
+	extra_perm = frappe.db.sql(query, as_list=1)
+	if extra_perm <> []:
+		for i in range(len(extra_perm)):
+			if extra_perm[i][1] in allowed_ids:
+				pass
+			else:
+				frappe.permissions.remove_user_permission("Customer", doc.name, extra_perm[i][1])

--- a/rigpl_erpnext/rigpl_erpnext/validations/customer.py
+++ b/rigpl_erpnext/rigpl_erpnext/validations/customer.py
@@ -9,19 +9,21 @@ def on_update(doc,method):
 	for d in doc.sales_team:
 		if d.sales_person:
 			s_person = frappe.get_doc("Sales Person", d.sales_person)
-			emp = frappe.get_doc("Employee", s_person.employee)
-			if emp.status == "Active":
-				frappe.permissions.add_user_permission("Customer", doc.name, emp.user_id)
-				allowed_ids.extend([emp.user_id])
-			else:
-				frappe.msgprint("Selected Sales Person is Not an Active Employee", raise_exception=1)
+			if s_person.employee:
+				emp = frappe.get_doc("Employee", s_person.employee)
+				if emp.status == "Active":
+					if emp.user_id:
+						frappe.permissions.add_user_permission("Customer", doc.name, emp.user_id)
+						allowed_ids.extend([emp.user_id])
+				else:
+					frappe.msgprint("Selected Sales Person is Not an Active Employee", raise_exception=1)
 	if doc.default_sales_partner:
 		s_partner = frappe.get_doc("Sales Partner", doc.default_sales_partner)
-		user = frappe.get_doc("User", s_partner.user)
-		if user.enabled == 1:
-			frappe.permissions.add_user_permission("Customer", doc.name, s_partner.user)
-			allowed_ids.extend([s_partner.user])
-			#frappe.msgprint(allowed_ids)
+		if s_partner.user:
+			user = frappe.get_doc("User", s_partner.user)
+			if user.enabled == 1:
+				frappe.permissions.add_user_permission("Customer", doc.name, s_partner.user)
+				allowed_ids.extend([s_partner.user])
 	
 	query = """SELECT name, parent from `tabDefaultValue` where defkey = 'Customer' AND defvalue = '%s'""" % (doc.name)
 	extra_perm = frappe.db.sql(query, as_list=1)

--- a/rigpl_erpnext/rigpl_erpnext/validations/lead.py
+++ b/rigpl_erpnext/rigpl_erpnext/validations/lead.py
@@ -6,7 +6,8 @@ import frappe.permissions
 
 def on_update(doc,method):
 	if doc.lead_owner:
-		frappe.permissions.add_user_permission("Lead", doc.name, doc.lead_owner, with_message = True)
+		#doc.contact_by = doc.lead_owner
+		frappe.permissions.add_user_permission("Lead", doc.name, doc.lead_owner)
 	
 	#Check if the lead is not in another user, if its there then delete the LEAD from the user's permission
 	query = """SELECT name, parent from `tabDefaultValue` where defkey = 'Lead' AND defvalue = '%s' AND parent <> '%s' """ % (doc.name, doc.lead_owner)

--- a/rigpl_erpnext/rigpl_erpnext/validations/lead.py
+++ b/rigpl_erpnext/rigpl_erpnext/validations/lead.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import frappe
+from frappe import msgprint
+import frappe.permissions
+
+def on_update(doc,method):
+	if doc.lead_owner:
+		frappe.permissions.add_user_permission("Lead", doc.name, doc.lead_owner, with_message = True)
+	
+	#Check if the lead is not in another user, if its there then delete the LEAD from the user's permission
+	query = """SELECT name, parent from `tabDefaultValue` where defkey = 'Lead' AND defvalue = '%s' AND parent <> '%s' """ % (doc.name, doc.lead_owner)
+	extra_perm = frappe.db.sql(query, as_list=1)
+	if extra_perm <> []:
+		for i in range(len(extra_perm)):
+			frappe.permissions.remove_user_permission("Lead", doc.name, extra_perm[i][1])
+	


### PR DESCRIPTION
-Changing Lead Owner creates a user permission for that user.
-Changing the sales team in Customer
-Changing the Sales Partner in the customer

The code checks for the user id linked and if the user id is found then the user permission is added to the required user and also deleted from unnecessary users.

So this basically means that user permission of the user can only be in those Sales Person's data who are mentioned in the Customer and similarly LEAD is also possible in only 1 user id which is mentioned in the Lead Owner.